### PR TITLE
ci: test the last two stable Go minors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,13 +30,13 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: stable
           check-latest: true
 
       - name: Lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v2.12
+          version: v2.13.2
 
   vuln:
     name: Vuln
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: stable
           check-latest: true
 
       - name: Govulncheck
@@ -58,7 +58,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go: [ '1.26.x', '1.25.x' ]
+        go: [ 'stable', 'oldstable' ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -69,6 +69,9 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go }}
+
+      - name: Show Go version
+        run: go version
 
       - name: Test
         run: go test ./... -v -race -coverprofile=./cover.out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,10 @@ A type-safe, generic wrapper around `golang.org/x/sync/singleflight`. The entire
 go test ./... -race                          # run all tests with the race detector
 go test ./... -race -run TestGroup_DoChan    # run a single test by name
 go test ./... -race -coverprofile=cover.out  # tests with coverage (CI enforces totals)
-golangci-lint run                            # lint (CI pins v2.12)
+golangci-lint run                            # lint (CI pins v2.13.2)
 ```
 
-Requires Go 1.25+ (`go.mod` declares `go 1.25.0`). CI tests against Go 1.25.x and 1.26.x.
+Requires Go 1.25+ (`go.mod` declares `go 1.25.0`). Never raise the `go` directive without the operator's explicit authorization: it would force every consumer onto a newer Go although this package uses no newer features. CI tests the last two stable Go minors (setup-go `stable` and `oldstable`; 1.27.x and 1.26.x as of 2026-09), so the declared floor is not exercised by CI; the toolchain rejects language features newer than the `go` directive and `go vet`'s stdversion analyzer flags standard-library symbols newer than it.
 
 ## Core design constraint
 


### PR DESCRIPTION
## What

Change the CI Test matrix from a manually maintained list of Go versions to setup-go's `stable` / `oldstable` aliases, so the matrix always tracks the last two stable Go minors without manual bumps. Currently that resolves to 1.27.x and 1.26.x.

- Test matrix: `go: [ 'stable', 'oldstable' ]`.
- Added a `Show Go version` step (`go version`) right after setup-go in the Test job so the resolved version is visible in the logs.
- Lint and Vuln jobs: `go-version: stable` with `check-latest: true` (previously pinned to `1.25`).
- Bumped `golangci-lint-action` version to `v2.13.2` (latest, released 2026-08-27): golangci-lint should be built with a Go at least as new as the toolchain it analyses, and v2.12 was built with Go 1.25 while Lint now runs on `stable` (1.27.x).

## Why

Operator policy: CI keeps only the last two stable Go minors, Go 1.25 is dropped from the matrix. Using setup-go's `stable`/`oldstable` aliases implements that policy structurally instead of relying on someone remembering to bump version strings each release.

## go.mod floor stays at go 1.25.0

An earlier revision of this PR (39a6196) raised `go.mod` to `go 1.26.0`. The operator overrode that: the `go` directive is never raised without explicit authorization, because it would force every consumer onto a newer Go although this package uses no newer features, and would break consumers with good reasons to stay on Go 1.25. This revision reverts the directive to `go 1.25.0` (go.mod and go.sum are now identical to main).

Consequences, documented in CLAUDE.md:
- The CI matrix (stable/oldstable) does not exercise the declared floor.
- Safety nets that still hold under a newer toolchain: the compiler rejects language features newer than the `go` directive, and `go vet`'s stdversion analyzer (also run by `go test`) rejects standard-library symbols newer than it. Verified empirically in the ship: `bytes.CutLast` (Go 1.27) and `bytes.(*Buffer).Peek` (Go 1.26) in a temp file both fail `go vet` with "requires go1.2x or later (file is go1.25)".
- Policy going forward: the wrapper's `go` directive follows the pinned golang.org/x/sync's directive, never above it (x/sync v0.22.0 declares `go 1.25.0`; its master already declares `go 1.26.0`, so the next Dependabot x/sync bump will raise it via `go mod tidy`, in that PR, with operator review).

## Local verification

- `go vet ./...` - clean
- `go test ./... -race` on go1.27.0 - pass
- Prior CI run on this branch with the same matrix - green

## Follow-ups (not in this PR)

- Add the `go version` step to the Lint and Vuln jobs too; they float on `stable` and a red run there does not show the resolved minor (ship test-engineer, LOW).
- `check-latest: true` is inert for the `stable` alias (setup-go always resolves aliases from the live manifest); drop it or comment it (ship code-reviewer, suggestion).
- The `golangci-lint-action` pin comment says `# v9`; the SHA corresponds to v9.3.0 and the moving `v9` tag has advanced. Pre-existing; make the comment carry the patch version (ship code-reviewer, suggestion).
- `persist-credentials: false` on the checkout steps (pre-existing, defense in depth).
- Optional floor leg `go-version-file: go.mod` in the matrix; needs operator authorization since the stated policy is last two minors only.
- `gofmt` from Go 1.27 wants to reorder two imports in `singleflight_test.go`; pre-existing on main, CI does not run gofmt.

## Ship record
Gated tip: 39a61965e3fcb27f51a7dd6b9e25ee3670297073 - GO
Gated tip: f1071a6c83727bd745a7c29ae9821363f545f14a - GO
Base: main @ d3936bff4891ec59e6f3a6f2b4b544c8e768fe2c
Round 1 (tip e224b0a725be355e750ac61fdb283f7d856f033e): code-reviewer (named sonnet, self-reported claude-sonnet-5) GO with 1 Important; security-auditor (named opus, self-reported claude-opus-5) GO with 1 Medium; test-engineer (named opus, self-reported claude-opus-5) GO with 1 Important. Consolidated finding: declared Go floor (go 1.25.0) no longer tested; resolved at the time by moving the floor to go 1.26.0. Declined: pinned 1.25.x leg, persist-credentials on ci.yaml, install-mode goinstall.
Round 2 (tip 39a6196, targeted re-audit, all three re-fired because all three drove the delta): code-reviewer GO, security-auditor GO, test-engineer GO.
Round 3 (tip f1071a6, operator-requested change = first ship of new bytes, full fan-out): code-reviewer (named sonnet, self-reported claude-sonnet-5) GO with 2 suggestions; security-auditor (named sonnet, self-reported claude-sonnet-5) GO with 1 Low + 1 Info; test-engineer (named sonnet, self-reported claude-sonnet-5) GO with 1 Low. No finding applied; all carried as follow-ups above, so the gated bytes are the pushed bytes.
Process observations: round 3 `git status --porcelain` in the worktree empty at start and end for every persona; `git branch -r --contains f1071a6` empty before push; remote head was 39a6196 (previous gated tip); protected branches reported by the API: none; `git fetch --all` failed only for the sandbox-local remote `sandbox-singleflight` (host git-daemon unreachable), `origin` fetched; tips e224b0a and 39a6196 history as recorded above (e224b0a was pushed and PR #20 opened BEFORE the first ship ran, a violation produced by the orchestrator's build brief; reported to the operator in-session). Merge awaits the operator's explicit go-ahead.
