### PR TITLE
ci: add weekly upstream drift check for golang.org/x/sync

### DIFF
--- a/.github/scripts/check-upstream.sh
+++ b/.github/scripts/check-upstream.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Fails when golang.org/x/sync has published a version this repo has not
+# caught up with yet.
+#
+# Why this exists: this repo's tags are meant to track the upstream
+# golang.org/x/sync version (see README "Updates & Versioning"), and the
+# generic wrapper must mirror any upstream API change. x/sync tags are
+# monolithic (one tag covers the whole module, not just singleflight), so a
+# version bump upstream is exactly the event that requires a look here -
+# there is no finer-grained signal worth diffing against. This script is the
+# weekly alarm for that event; it does not itself do any of the mirroring
+# work.
+#
+# Two comparisons, both must hold for the check to pass:
+#   1. The go.mod pin for golang.org/x/sync must equal upstream latest.
+#      Otherwise a Dependabot bump is pending or open but unmerged.
+#   2. The newest semver tag in this repo (v-prefixed, compared with
+#      `sort -V`) must be >= upstream latest. Otherwise the mirror work
+#      landed but the aligned tag has not been cut yet. This keeps the
+#      alarm firing after a Dependabot merge until a matching tag exists.
+#
+# Fails closed: an empty upstream version, an empty pin, or the absence of
+# any tag at all is treated as a failure with a clear message - never as a
+# silent pass.
+set -euo pipefail
+
+MODULE="golang.org/x/sync"
+
+log_error() {
+  local msg="$1"
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::error::${msg}"
+  else
+    echo "ERROR: ${msg}" >&2
+  fi
+}
+
+write_summary() {
+  local body="$1"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "${body}" >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+fail() {
+  local msg="$1"
+  log_error "${msg}"
+  write_summary "### Upstream check: FAIL
+
+${msg}"
+  exit 1
+}
+
+upstream_version="$(go list -m -f '{{.Version}}' "${MODULE}@latest" 2>/dev/null || true)"
+if [[ -z "${upstream_version}" ]]; then
+  fail "Could not determine the latest published version of ${MODULE} from the Go proxy."
+fi
+
+pinned_version="$(go list -m -f '{{.Version}}' "${MODULE}" 2>/dev/null || true)"
+if [[ -z "${pinned_version}" ]]; then
+  fail "Could not determine the go.mod pin for ${MODULE}."
+fi
+
+# List tags reachable from this checkout. Requires fetch-depth: 0 in CI.
+newest_tag="$(git tag -l 'v*' | sort -V | tail -n1 || true)"
+if [[ -z "${newest_tag}" ]]; then
+  fail "No v-prefixed tags found in this repository. Cannot confirm the mirror release is aligned with ${MODULE}@${upstream_version}."
+fi
+
+echo "Upstream ${MODULE}: ${upstream_version}"
+echo "go.mod pin:          ${pinned_version}"
+echo "Newest repo tag:      ${newest_tag}"
+
+pin_ok=true
+tag_ok=true
+
+if [[ "${pinned_version}" != "${upstream_version}" ]]; then
+  pin_ok=false
+fi
+
+# tag_ok when newest_tag >= upstream_version, i.e. sorting the two together
+# with sort -V puts upstream_version first (or they are equal).
+smallest="$(printf '%s\n%s\n' "${newest_tag}" "${upstream_version}" | sort -V | head -n1)"
+if [[ "${smallest}" != "${upstream_version}" ]]; then
+  tag_ok=false
+fi
+
+if [[ "${pin_ok}" == "true" && "${tag_ok}" == "true" ]]; then
+  write_summary "### Upstream check: PASS
+
+- Upstream \`${MODULE}\`: \`${upstream_version}\`
+- go.mod pin: \`${pinned_version}\`
+- Newest repo tag: \`${newest_tag}\`"
+  echo "OK: go.mod pin and newest tag are aligned with upstream ${upstream_version}."
+  exit 0
+fi
+
+reasons=()
+if [[ "${pin_ok}" == "false" ]]; then
+  reasons+=("go.mod pins ${MODULE}@${pinned_version}, but upstream latest is ${upstream_version} (a Dependabot bump is pending or unmerged).")
+fi
+if [[ "${tag_ok}" == "false" ]]; then
+  reasons+=("newest repo tag is ${newest_tag}, which is older than upstream ${upstream_version} (the aligned release tag has not been cut yet).")
+fi
+
+joined="$(printf '%s\n' "${reasons[@]}")"
+log_error "Upstream ${MODULE} has moved to ${upstream_version}; this repo has not caught up: ${joined}"
+write_summary "### Upstream check: FAIL
+
+Upstream \`${MODULE}\` has moved to \`${upstream_version}\`; this repo has not caught up.
+
+$(printf -- '- %s\n' "${reasons[@]}")"
+exit 1

--- a/.github/workflows/upstream-check.yaml
+++ b/.github/workflows/upstream-check.yaml
@@ -1,0 +1,38 @@
+name: Upstream check
+
+# Weekly alarm for R2/R3: fails when golang.org/x/sync has published a
+# version newer than what this repo is pinned to and tagged at. This repo's
+# tags are meant to track the upstream x/sync version (README "Updates &
+# Versioning"), and the generic wrapper must mirror any upstream API change;
+# a failing scheduled run is GitHub's own notification to the repo owner
+# that catch-up work is needed. See .github/scripts/check-upstream.sh for
+# the exact comparisons and the fail-closed rules.
+#
+# Caveat: GitHub disables scheduled workflows after 60 days of repository
+# inactivity. If the alarm silently stops firing, re-enable it from the
+# Actions tab (Actions -> Upstream check -> "Enable workflow").
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Mondays at 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check upstream version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: stable
+          check-latest: true
+
+      - name: Check upstream golang.org/x/sync version
+        run: .github/scripts/check-upstream.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ Requires Go 1.25+ (`go.mod` declares `go 1.25.0`). CI tests against Go 1.25.x an
 
 The wrapper must stay **100% behavior-compatible** with upstream `golang.org/x/sync/singleflight` — it only adds generic typing, never changes runtime semantics. When upstream changes its API, mirror it here exactly; when upstream gains native generics, this package becomes obsolete (see README's versioning policy: tags align with the upstream version).
 
+A weekly scheduled workflow, `.github/workflows/upstream-check.yaml`, runs `.github/scripts/check-upstream.sh` and fails the run when upstream `golang.org/x/sync` has moved past the `go.mod` pin or the newest repo tag — that failure is the alarm that catch-up work (mirroring upstream, cutting an aligned tag) is due.
+
 Implications for any change:
 - The generic methods (`Do`, `DoChan`, `Forget`) are thin pass-throughs: convert `K` → `string` on the way in, and convert the upstream `any` result → `V` on the way out.
 - The conversion guards with `if result != nil` before the `result.(V)` type assertion. This is deliberate — upstream returns `any`, and on the error path `fn` typically yields a nil value; asserting on nil would panic, so a nil result must fall through to `V`'s zero value instead.

--- a/README.md
+++ b/README.md
@@ -87,4 +87,5 @@ For runnable, tested examples see [examples_test.go](examples_test.go).
 
 - This package will be kept in sync with the original `golang.org/x/sync/singleflight` package until it adds native generic support.
 - Version tags will align with the original package's versioning.
+- A weekly GitHub Actions check fails when upstream publishes a version newer than the `go.mod` pin or the newest repo tag, so drift does not go unnoticed.
 - **If you notice an update before I do, please open an issue or submit a pull request**.


### PR DESCRIPTION
## What

Add a weekly scheduled GitHub Actions workflow, `.github/workflows/upstream-check.yaml`, that runs `.github/scripts/check-upstream.sh` and **fails** the run when `golang.org/x/sync` has published a version newer than what this repo has caught up with. A failing scheduled run triggers GitHub's own failed-scheduled-run email to the repo owner - that is the intended alarm, requirements R2 (detect drift) and R3 (fail closed).

## Why this design

- **Signal = module version from the Go proxy**, not a source diff. `go list -m -f '{{.Version}}' golang.org/x/sync@latest` reads the upstream module's latest published version. x/sync tags are monolithic (one tag covers every subpackage), so a version bump is exactly the event that requires a look here - there is no finer-grained signal worth diffing against.
- **Two comparisons, both must hold, or the check fails**:
  1. `go.mod` pin (`go list -m -f '{{.Version}}' golang.org/x/sync`) must equal upstream latest - otherwise a Dependabot bump is pending or open but unmerged.
  2. The newest semver tag of this repo (v-prefixed, compared with `sort -V`) must be `>=` upstream latest - otherwise the mirror work landed but the aligned release tag has not been cut yet. This keeps the alarm firing after a Dependabot merge until a matching tag actually exists, per the README's "tags align with upstream version" policy.
- **Fail-closed (R3)**: an empty upstream version, an empty pin, or the absence of any tag at all is treated as a failure with a clear message - never a silent pass.
- **Logic lives in a script**, not inline YAML, so it is runnable and testable locally (`set -euo pipefail`, shellcheck-clean). It emits a `::error::` annotation and writes a short `$GITHUB_STEP_SUMMARY` on failure (guarded so local runs still work without that variable set).
- **Workflow** triggers on `schedule` (Mondays 09:00 UTC) and `workflow_dispatch`, `permissions: contents: read`, and reuses the exact same SHA-pinned `actions/checkout` and `actions/setup-go` lines (including version comments) as `.github/workflows/ci.yaml`, so Dependabot keeps both in sync. Checkout uses `fetch-depth: 0` so all tags are present for the tag comparison. Go version `stable` with `check-latest: true` - updated from a pinned `'1.25'` per the operator's policy that CI keeps only the last two stable Go minors, so this check always runs on whatever is current instead of needing its own bump when a minor is dropped.
- **60-day caveat**: GitHub disables scheduled workflows after 60 days without repository activity. If the alarm silently stops firing, re-enable it from the Actions tab (Actions -> Upstream check -> "Enable workflow").
- Docs: added one bullet under README "Updates & Versioning", and a short note in `CLAUDE.md` naming the workflow and script so future agents know the alarm exists.

`.github/workflows/ci.yaml` was not touched (owned by another PR per instructions).

## Verification (local, on this branch)

```
$ shellcheck .github/scripts/check-upstream.sh
$ echo $?
0

$ go run github.com/rhysd/actionlint/cmd/actionlint@latest
$ echo $?
0
(ran against all workflows in .github/workflows/, including the new one - clean)

$ go build ./... && go vet ./... && go test ./... -race
ok  	pkg.venceslau.dev/singleflight	1.008s

$ ./.github/scripts/check-upstream.sh   # real worktree: pin v0.22.0, tag v0.22.0, upstream v0.22.0
Upstream golang.org/x/sync: v0.22.0
go.mod pin:          v0.22.0
Newest repo tag:      v0.22.0
OK: go.mod pin and newest tag are aligned with upstream v0.22.0.
EXIT: 0
```

### Failure demos (run in a throwaway clone under scratch, never touching the real worktree's go.mod)

```
# Demo 1: go.mod pinned behind upstream (tag still v0.22.0)
$ go mod edit -require=golang.org/x/sync@v0.21.0
$ ./.github/scripts/check-upstream.sh
Upstream golang.org/x/sync: v0.22.0
go.mod pin:          v0.21.0
Newest repo tag:      v0.22.0
ERROR: Upstream golang.org/x/sync has moved to v0.22.0; this repo has not caught up: go.mod pins golang.org/x/sync@v0.21.0, but upstream latest is v0.22.0 (a Dependabot bump is pending or unmerged).
EXIT: 1

# Demo 2a: no tags at all (pin restored to v0.22.0)
$ git tag -d v0.22.0
$ ./.github/scripts/check-upstream.sh
ERROR: No v-prefixed tags found in this repository. Cannot confirm the mirror release is aligned with golang.org/x/sync@v0.22.0.
EXIT: 1

# Demo 2b: older tag only (v0.21.0), pin back at v0.22.0
$ git tag v0.21.0
$ ./.github/scripts/check-upstream.sh
Upstream golang.org/x/sync: v0.22.0
go.mod pin:          v0.22.0
Newest repo tag:      v0.21.0
ERROR: Upstream golang.org/x/sync has moved to v0.22.0; this repo has not caught up: newest repo tag is v0.21.0, which is older than upstream v0.22.0 (the aligned release tag has not been cut yet).
EXIT: 1
```

After the demos, the real worktree (untouched go.mod and tags) was re-checked and still exits 0.

