### PR TITLE
chore: gofmt import order in singleflight_test.go

### DIFF
--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 	"testing/synctest"
 
-	"pkg.venceslau.dev/singleflight"
 	upstream "golang.org/x/sync/singleflight"
+	"pkg.venceslau.dev/singleflight"
 )
 
 // cacheKey exercises the K ~string constraint with a named string type rather


### PR DESCRIPTION
## What

`gofmt -w singleflight_test.go` with Go 1.27's gofmt: the two import lines in the second import group are swapped into sorted order. No code change; go.mod and go.sum untouched.

## Why

`gofmt -l .` on Go 1.27.0 lists the file. CI does not run gofmt, so this was invisible there; keeping the tree gofmt-clean avoids noise in every future diff made with a current toolchain. Operator approved applying the reorder.

## Verification

- `gofmt -l .` prints nothing
- `go vet ./...` clean
- `go test ./... -race` pass, 100.0% coverage (CI gate 93%)

## Ship record
Gated tip: 00d6e21ce6fc20cf8944cae9ade533ecefa86e79 - GO
Base: main @ d3936bff4891ec59e6f3a6f2b4b544c8e768fe2c
Round 1 (first ship, full fan-out): code-reviewer (named haiku, self-reported claude-haiku-4-5-20251001) GO, no findings; security-auditor (named haiku, self-reported claude-haiku-4-5-20251001) GO, no findings; test-engineer (named haiku, self-reported claude-haiku-4-5-20251001) GO, no findings.
Process observations: `git status --porcelain` empty at start and end for every persona; before push `git ls-remote --heads origin chore/gofmt-imports` empty (exit 0), `gh pr list --head chore/gofmt-imports --state all` empty, `git branch -r --contains 00d6e21` empty; protected branches reported by the API: none; pushed only after GO. Merge awaits the operator's explicit go-ahead.
